### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ huggingface_hub==0.9.0
 scipy==1.9.0
 streamlit==1.12.0
 watchdog==2.1.9
+ftfy==6.1.1


### PR DESCRIPTION
Add ftfy 6.1.1 to stop OpenAIGPTTokenizer's warning/fallback to  BERT BasicTokenizer.