### PR TITLE
Bugfix/Seed Value

### DIFF
--- a/demo_web.py
+++ b/demo_web.py
@@ -13,8 +13,6 @@ from stable_diffusion_engine import StableDiffusionEngine
 # scheduler
 from diffusers import PNDMScheduler
 
-def clicked_generate():
-    st.session_state.clicked_generate = True
 
 def run(engine):
     # init session_state if needed
@@ -84,6 +82,9 @@ def run(engine):
                 min_value = 0,
                 max_value = 2 ** 31
             )
+
+            def clicked_generate():
+                st.session_state.clicked_generate = True
 
             generate = st.form_submit_button(
                 label = 'Generate',

--- a/demo_web.py
+++ b/demo_web.py
@@ -13,15 +13,15 @@ from stable_diffusion_engine import StableDiffusionEngine
 # scheduler
 from diffusers import PNDMScheduler
 
-seedValue = random.randint(0, 2 ** 31)
+seed_value = random.randint(0, 2 ** 31)
 
-def updateSeed():
-    if st.session_state.seed == seedValue:
+def update_seed():
+    if st.session_state.seed == seed_value:
         del st.session_state.seed
 
 def run(engine):
     if 'seed' not in st.session_state:
-        st.session_state.seed = seedValue
+        st.session_state.seed = seed_value
 
     with st.form(key="request"):
         with st.sidebar:
@@ -80,7 +80,7 @@ def run(engine):
 
             generate = st.form_submit_button(
                 label = 'Generate',
-                on_click = updateSeed
+                on_click = update_seed
             )
 
         if prompt:

--- a/demo_web.py
+++ b/demo_web.py
@@ -13,8 +13,16 @@ from stable_diffusion_engine import StableDiffusionEngine
 # scheduler
 from diffusers import PNDMScheduler
 
+seedValue = random.randint(0, 2 ** 31)
+
+def updateSeed():
+    if st.session_state.seed == seedValue:
+        del st.session_state.seed
 
 def run(engine):
+    if 'seed' not in st.session_state:
+        st.session_state.seed = seedValue
+
     with st.form(key="request"):
         with st.sidebar:
             prompt = st.text_area(label='Enter prompt')
@@ -65,12 +73,15 @@ def run(engine):
 
             seed = st.number_input(
                 label='seed',
+                key='seed',
                 min_value = 0,
-                max_value = 2 ** 31,
-                value = random.randint(0, 2 ** 31)
+                max_value = 2 ** 31
             )
 
-            generate = st.form_submit_button(label = 'Generate')
+            generate = st.form_submit_button(
+                label = 'Generate',
+                on_click = updateSeed
+            )
 
         if prompt:
             np.random.seed(seed)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ huggingface_hub==0.9.0
 scipy==1.9.0
 streamlit==1.12.0
 watchdog==2.1.9
+ftfy==6.1.1


### PR DESCRIPTION
I noticed that the seed value used to render is not the seed value when clicking generate.

This PR uses `session_state` to persist the `seed` value so that the subsequent generation will use it. It still maintains the existing behavior of selecting a new random seed value per generation, unless the user manually enters a specific seed value, in which case the same manually entered seed value will continue to be used.