### PR TITLE
Default output name changed to timestamped 

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,4 +1,5 @@
 # -- coding: utf-8 --`
+import datetime
 import argparse
 import os
 # engine
@@ -69,6 +70,6 @@ if __name__ == "__main__":
     # inpainting
     parser.add_argument("--mask", type=str, default=None, help="mask of the region to inpaint on the initial image")
     # output name
-    parser.add_argument("--output", type=str, default="output.png", help="output image name")
+    parser.add_argument("--output", type=str, default="out_" + datetime.datetime.today().isoformat('_', 'seconds') + ".png", help="output image name")
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
Default demo.py output file name changed from static output.png to timestamped filename a for better user experience.  

original: output.png
new: out_YYYY-MM-DD_ss:mm:ss.png
example: out_2022-10-23_23:46:53.png