### PR TITLE
Update openvino to 2022.3 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ opencv-python==4.5.5.64
 transformers==4.16.2
 diffusers==0.2.4
 tqdm==4.64.0
-openvino==2022.1.0
+openvino==2022.3.0
 huggingface_hub==0.9.0
 scipy==1.9.0
 streamlit==1.12.0


### PR DESCRIPTION
New version of OpenVINO has [improved support for Stable Diffusion](https://www.intel.com/content/www/us/en/developer/articles/release-notes/openvino-2022-3-lts-relnotes.html) on Intel CPU and GPU. Also, 4th Gen Xeon is now supported and stable_diffusion.openvino will be used in a [webinar on Jan 24th](https://cnvrg.io/webinars-and-workshops/stable-diffusion-workshop/). Please consider upgrading requirements.txt to use OpenVINO 2022.3 LTS. 

Thank you, 
Ryan