### PR TITLE
Add conda env to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Implementation of Text-To-Image generation using Stable Diffusion on Intel CPU.
 ```bash
 python -m pip install --upgrade pip
 pip install openvino-dev[onnx,pytorch]==2022.3.0
+git clone https://github.com/bes-dev/stable_diffusion.openvino.git
+cd stable_diffusion.openvino
 pip install -r requirements.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Implementation of Text-To-Image generation using Stable Diffusion on Intel CPU.
 
 ## Install requirements
 
-* Set up conda environment 
+* Set up conda environment (optional)
 * Set up and update PIP to the highest version
 * Install OpenVINO™ Development Tools 2022.1 release with PyPI
 * Download requirements

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ Implementation of Text-To-Image generation using Stable Diffusion on Intel CPU.
 
 ## Install requirements
 
+* Set up conda environment 
 * Set up and update PIP to the highest version
 * Install OpenVINO™ Development Tools 2022.1 release with PyPI
 * Download requirements
 
 ```bash
+conda create -n py3.9 python=3.9
+conda activate py3.9
 python -m pip install --upgrade pip
 pip install openvino-dev[onnx,pytorch]==2022.3.0
 git clone https://github.com/bes-dev/stable_diffusion.openvino.git


### PR DESCRIPTION
I think it would be useful for the average user to have two changes to the readme for a smoother install: 
1) Cloning and cd'ing in the repo is missing 
2) Setting up some kind of virtual env (conda, venv etc.) should be recommended so that users don't accidentally mess up their base env. 

