### PR TITLE
UNET model input precision conversion fix

### DIFF
--- a/stable_diffusion_engine.py
+++ b/stable_diffusion_engine.py
@@ -183,7 +183,7 @@ class StableDiffusionEngine:
             # predict the noise residual
             noise_pred = result(self.unet.infer_new_request({
                 "latent_model_input": latent_model_input,
-                "t": t,
+                "t": np.float64(t),
                 "encoder_hidden_states": text_embeddings
             }))
 


### PR DESCRIPTION
This PR fixes an issue reported both here https://stackoverflow.com/questions/75213370/stable-diffusion-with-openvino-failed-to-set-input-blob-with-precision-i64-if and here https://github.com/bes-dev/stable_diffusion.openvino/issues/118

The UNET model expects f64 data type for the input named "t" while the values generated by tqdm are 64-bit ints.