### PR TITLE
adding GPU caching to reduce init time

### DIFF
--- a/stable_diffusion_engine.py
+++ b/stable_diffusion_engine.py
@@ -27,6 +27,8 @@ class StableDiffusionEngine:
         self.scheduler = scheduler
         # models
         self.core = Core()
+        self.core.set_property({'CACHE_DIR': './cache'})
+
         # text features
         self._text_encoder = self.core.read_model(
             hf_hub_download(repo_id=model, filename="text_encoder.xml"),


### PR DESCRIPTION
Added the caching for OpenVINO and so when we use GPU it won't need to recompile. 

https://docs.openvino.ai/latest/openvino_docs_OV_UG_Model_caching_overview.html

