### PR TITLE
Fix of a deprecated symbol usage

### DIFF
--- a/stable_diffusion_engine.py
+++ b/stable_diffusion_engine.py
@@ -150,7 +150,7 @@ class StableDiffusionEngine:
             init_latents = self._encode_image(init_image)
             init_timestep = int(num_inference_steps * strength) + offset
             init_timestep = min(init_timestep, num_inference_steps)
-            timesteps = np.array([[self.scheduler.timesteps[-init_timestep]]]).astype(np.long)
+            timesteps = np.array([[self.scheduler.timesteps[-init_timestep]]]).astype(int)
             noise = np.random.randn(*self.latent_shape)
             latents = self.scheduler.add_noise(init_latents, noise, timesteps)[0]
 


### PR DESCRIPTION
In numpy 1.24 some previously deprecated  have been removed. `np.long` is one of them and it makes the script fail when used with this version.