### PR TITLE
fix load_engine function not defined

### DIFF
--- a/demo_web.py
+++ b/demo_web.py
@@ -120,5 +120,5 @@ if __name__ == "__main__":
         # so we have to do a hard exit.
         os._exit(e.code)
 
-    engine = load_engine(args)
+    engine = load_pipeline(args)
     run(engine)


### PR DESCRIPTION
streamlit run demo_web.py 

```
File "/stable_diffusion.openvino/demo_web.py", line 123, in <module>
    engine = load_engine(args)
NameError: name 'load_engine' is not defined
```
found that the load_pipeline function is defined, but the load_engine function is called