### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.19.5
+numpy==1.21.2
 opencv-python==4.5.5.64
 transformers==4.16.2
 diffusers==0.2.4


### PR DESCRIPTION
Numpy must be 1.21.2 or greater based on dependency of opencv-python 4.5.5.64